### PR TITLE
fix!: `oxc.configPath` defaults to  `null`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
           "description": "Enable oxc language server"
         },
         "oxc.configPath": {
-          "type": "string",
-          "scope": "window",
-          "default": ".eslintrc",
-          "description": "Path to ESlint configuration."
+          "type": ["string", "null"],
+          "scope": "resource",
+          "default": null,
+          "description": "Path to oxlint configuration. Keep it empty to enable nested configuration."
         },
         "oxc.binPath": {
           "type": "string",


### PR DESCRIPTION
closes https://github.com/oxc-project/coc-oxc/issues/23

Now it is align with VSCode settings:
https://github.com/oxc-project/oxc/blob/b8790c29d95c4b12aff1781535c85fa1780100dd/editors/vscode/package.json#L110-L118