### PR TITLE
feat: add `oxc.oxfmt.formatterPriority` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 - `oxc.oxfmt.enable`: Enable oxfmt formatting (default: `true`)
 - `oxc.oxfmt.binPath`: Path to the `oxfmt` binary (default: searches in `node_modules/.bin`)
+- `oxc.oxfmt.formatterPriority`: Priority of formatter provider (default: `1`). Higher priority wins when multiple formatters are registered. Set to `-1` to make it lower priority than other formatters.
 
 ## Format on Save
 
@@ -33,15 +34,13 @@ To enable format on save, add this to your coc-config (`:CocConfig`):
 
 ```json
 {
-  "oxc.oxfmt.enable": true,
-  "javascript.format.enable": false,
-  "typescript.format.enable": false,
-  "biome.format.enable": false,
-  "prettier.enable": false
+  "coc.preferences.formatterExtension": "coc-oxc"
 }
 ```
 
-This disables ts language server (via `coc-tsserver`), Biome and prettier formatting.
+This tells coc.nvim to always use coc-oxc as the formatter, avoiding conflicts with other formatters like coc-biome or coc-prettier.
+
+Alternatively, you can set `oxc.oxfmt.formatterPriority` to control the priority (default `1`, which is higher than most other formatters).
 
 You can also format manually with `:call CocAction('format')`
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the `oxfmt` binary"
+        },
+        "oxc.oxfmt.formatterPriority": {
+          "type": "number",
+          "default": 1,
+          "description": "Priority of formatter provider, default to 1 that is higher than other language server formatters. Change to -1 to make it lower priority."
         }
       }
     },

--- a/src/common.ts
+++ b/src/common.ts
@@ -99,11 +99,14 @@ function createClient(
     },
   ];
 
+  const formatterPriority = settings.formatterPriority as number | undefined;
+
   const clientOptions: LanguageClientOptions = {
     outputChannel,
     progressOnInitialization: true,
     documentSelector,
     initializationOptions,
+    ...(formatterPriority != null && { formatterPriority }),
   };
 
   return new LanguageClient(config.name, config.name, createServerOptions(command), clientOptions);


### PR DESCRIPTION
## Summary

- Add `oxc.oxfmt.formatterPriority` config option (default: `1`) to control formatter precedence, resolving conflicts with other formatters like coc-biome
- Update README to recommend `coc.preferences.formatterExtension` for simpler formatter selection

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)