### PR TITLE
fix: remove --help probe that prevents LSP startup with vite-plus

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,4 @@
 import { existsSync } from "node:fs";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { join } from "path";
 import {
   Executable,
@@ -14,8 +12,6 @@ import {
   window,
   workspace,
 } from "coc.nvim";
-
-const execFileAsync = promisify(execFile);
 
 type Optional<T> = T | null;
 
@@ -33,15 +29,6 @@ function findBinary(config: ClientConfig): Optional<string> {
 
   bin = join(workspace.root, "node_modules", ".bin", config.name);
   return existsSync(bin) ? bin : null;
-}
-
-async function supportsLsp(command: string): Promise<boolean> {
-  try {
-    const { stdout } = await execFileAsync(command, ["--help"]);
-    return stdout.includes("--lsp");
-  } catch {
-    return false;
-  }
 }
 
 function createServerOptions(command: string): ServerOptions {
@@ -147,10 +134,6 @@ export function createActivate(config: ClientConfig): (context: ExtensionContext
 
     const command = findBinary(config);
     if (!command) {
-      return;
-    }
-
-    if (!(await supportsLsp(command))) {
       return;
     }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => {
   const configurationListeners: Array<
     (event: { affectsConfiguration: (section: string) => boolean }) => void
   > = [];
-  const promisifyCustom = Symbol.for("nodejs.util.promisify.custom");
 
   class MockLanguageClient {
     id: string;
@@ -36,10 +35,6 @@ const mocks = vi.hoisted(() => {
       createdClients.push(this);
     }
   }
-
-  const execFile = vi.fn();
-  const execFileAsync = vi.fn();
-  Object.defineProperty(execFile, promisifyCustom, { value: execFileAsync });
 
   const existsSync = vi.fn((_path: string) => false);
 
@@ -108,9 +103,6 @@ const mocks = vi.hoisted(() => {
     outputChannels.length = 0;
     configurationListeners.length = 0;
 
-    execFile.mockClear();
-    execFileAsync.mockReset();
-    execFileAsync.mockResolvedValue({ stdout: "--lsp", stderr: "" });
     existsSync.mockReset();
     existsSync.mockImplementation((_path: string) => false);
 
@@ -130,9 +122,6 @@ const mocks = vi.hoisted(() => {
     registeredCommands,
     outputChannels,
     configurationListeners,
-    promisifyCustom,
-    execFile,
-    execFileAsync,
     existsSync,
     commands,
     services,
@@ -143,23 +132,9 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("node:child_process", () => ({
-  execFile: mocks.execFile,
-}));
-
 vi.mock("node:fs", () => ({
   existsSync: mocks.existsSync,
 }));
-
-vi.mock("node:util", async () => {
-  const actual = await vi.importActual<typeof import("node:util")>("node:util");
-  return {
-    ...actual,
-    promisify: vi.fn((fn: Record<PropertyKey, unknown>) => {
-      return fn[mocks.promisifyCustom] as unknown;
-    }),
-  };
-});
 
 vi.mock("coc.nvim", () => ({
   LanguageClient: mocks.MockLanguageClient,
@@ -204,7 +179,6 @@ describe("extension activation", () => {
       "oxfmt.showOutputChannel",
       "oxfmt.restartServer",
     ]);
-    expect(mocks.execFileAsync).toHaveBeenCalledTimes(2);
 
     const [oxlintClient, oxfmtClient] = mocks.createdClients;
     expect(oxlintClient.serverOptions).toMatchObject({
@@ -263,7 +237,6 @@ describe("extension activation", () => {
     expect(mocks.createdClients).toHaveLength(0);
     expect(mocks.registeredClients).toHaveLength(0);
     expect(mocks.registeredCommands).toHaveLength(0);
-    expect(mocks.execFileAsync).not.toHaveBeenCalled();
     expect(context.subscriptions).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- The vite-plus wrappers at `node_modules/.bin/{oxlint,oxfmt}` reject any invocation that isn't `--lsp` (or `--stdin-filepath` for oxfmt) and exit with code 1.
- `supportsLsp` in `src/common.ts` ran `<bin> --help` and checked the output for `--lsp`, so under vite-plus it always returned `false` and the language client was never registered — silently disabling format-on-save and lint diagnostics.
- Drop the probe and trust the discovered binary, matching how `oxc-vscode` handles binary discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)