### PR TITLE
fix: set oxfmt formatter priority to win over conflicting LSPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 - `oxc.oxfmt.enable`: Enable oxfmt formatting (default: `true`)
 - `oxc.oxfmt.binPath`: Path to the `oxfmt` binary (default: searches in `node_modules/.bin`)
+- `oxc.oxfmt.formatterPriority`: Priority used when multiple formatters are registered for a language. Higher wins. Set to a negative value to defer to other formatters (default: `1`)
 
 ## Format on Save
 
@@ -34,14 +35,19 @@ To enable format on save, add this to your coc-config (`:CocConfig`):
 ```json
 {
   "oxc.oxfmt.enable": true,
-  "javascript.format.enable": false,
-  "typescript.format.enable": false,
-  "biome.format.enable": false,
-  "prettier.enable": false
+  "coc.preferences.formatterExtension": "coc-oxc"
 }
 ```
 
-This disables ts language server (via `coc-tsserver`), Biome and prettier formatting.
+`coc.preferences.formatterExtension` tells coc.nvim to use coc-oxc whenever it is available, which avoids conflicts with other extensions that also register an LSP formatter (e.g. `coc-biome`, `coc-tsserver`, `coc-prettier`). You can scope it per-language if you want a different formatter for some files:
+
+```json
+{
+  "[json]": { "coc.preferences.formatterExtension": "coc-prettier" }
+}
+```
+
+oxfmt also registers itself with `oxc.oxfmt.formatterPriority` `1` by default, which outranks any extension that does not set a priority. Tune that value if you need finer control.
 
 You can also format manually with `:call CocAction('format')`
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the `oxfmt` binary"
+        },
+        "oxc.oxfmt.formatterPriority": {
+          "type": "number",
+          "default": 1,
+          "description": "Priority of the oxfmt formatter when multiple formatters are registered for a language. Higher wins. Set to a negative value to defer to other formatters."
         }
       }
     },

--- a/src/common.ts
+++ b/src/common.ts
@@ -62,30 +62,13 @@ function createClient(
     scheme: "file",
   }));
 
-  // Format settings to match what oxc LSP server expects
-  // Map coc-oxc config names to LSP server expected names
   const options: Record<string, any> = {};
-
-  if (config.name === "oxfmt") {
-    // For oxfmt: map 'enable' to 'fmt.experimental'
-    if (settings.enable !== undefined) {
-      options["fmt.experimental"] = settings.enable;
-    }
-    if (settings.binPath) {
-      options["fmt.binPath"] = settings.binPath;
-    }
-  } else if (config.name === "oxlint") {
-    // For oxlint: keep existing config names
-    Object.assign(options, settings);
-  }
-
   const initializationOptions = [
     {
       workspaceUri: `file://${workspace.root}`,
       options,
     },
   ];
-
   const clientOptions: LanguageClientOptions = {
     outputChannel,
     progressOnInitialization: true,
@@ -94,7 +77,15 @@ function createClient(
   };
 
   if (config.name === "oxfmt") {
+    if (settings.enable !== undefined) {
+      options["fmt.experimental"] = settings.enable;
+    }
+    if (settings.binPath) {
+      options["fmt.binPath"] = settings.binPath;
+    }
     clientOptions.formatterPriority = settings.formatterPriority ?? 1;
+  } else if (config.name === "oxlint") {
+    Object.assign(options, settings);
   }
 
   return new LanguageClient(config.name, config.name, createServerOptions(command), clientOptions);

--- a/src/common.ts
+++ b/src/common.ts
@@ -93,6 +93,10 @@ function createClient(
     initializationOptions,
   };
 
+  if (config.name === "oxfmt") {
+    clientOptions.formatterPriority = settings.formatterPriority ?? 1;
+  }
+
   return new LanguageClient(config.name, config.name, createServerOptions(command), clientOptions);
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -216,7 +216,25 @@ describe("extension activation", () => {
           },
         },
       ],
+      formatterPriority: 1,
     });
+    expect(oxlintClient.clientOptions).not.toHaveProperty("formatterPriority");
+  });
+
+  it("honors a configured oxfmt formatterPriority", async () => {
+    mocks.configurationValues["oxc.oxlint"] = { enable: false };
+    mocks.configurationValues["oxc.oxfmt"] = {
+      enable: true,
+      binPath: "/mock/bin/oxfmt",
+      formatterPriority: 5,
+    };
+    mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxfmt");
+
+    const { activate } = await import("./index");
+    await activate({ subscriptions: [] as unknown[] } as never);
+
+    const oxfmtClient = mocks.createdClients.find((client) => client.name === "oxfmt");
+    expect(oxfmtClient?.clientOptions).toMatchObject({ formatterPriority: 5 });
   });
 
   it("skips activation for disabled clients", async () => {


### PR DESCRIPTION
## Summary

Closes #158.

`coc-oxc` and `coc-biome` both register their LSP as a formatter via `services.registerLanguageClient`, which advertises `documentFormattingProvider` to coc.nvim with priority `0`. When both are active the pick comes down to registration order — explaining the user's logs: oxfmt runs on a fast save (before biome finishes starting), and on slower saves biome takes over (or, with `files.formatter.enabled = false` in `biome.jsonc`, nothing runs because biome's formatter is a no-op).

Two fixes:

- **Priority** — pass `formatterPriority` on the oxfmt `LanguageClientOptions` (default `1`, exposed as `oxc.oxfmt.formatterPriority`). coc.nvim's selection algorithm adds priority to the match score, so a default `1` outranks any extension that does not set one. Mirrors what `coc-prettier` does.
- **Docs** — the README recipe told users to set `biome.format.enable: false`, which is not a real coc-biome config (only `biome.enable`, `biome.bin`, `biome.requireConfiguration`, `biome.trace.server` exist). Replaced with `coc.preferences.formatterExtension: "coc-oxc"`, which coc.nvim's `getFormatProvider` honors before falling back to priority, bypassing the race entirely. Per-language scoping example included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)