### PR TITLE
docs: correct formatterPriority description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 - `oxc.oxfmt.enable`: Enable oxfmt formatting (default: `true`)
 - `oxc.oxfmt.binPath`: Path to the `oxfmt` binary (default: searches in `node_modules/.bin`)
-- `oxc.oxfmt.formatterPriority`: Priority used when multiple formatters are registered for a language. Higher wins. Set to a negative value to defer to other formatters (default: `1`)
+- `oxc.oxfmt.formatterPriority`: Priority used when multiple formatters are registered for a language. Only positive values boost; the default `1` outranks formatters that do not set a priority. To defer for a given language, use `coc.preferences.formatterExtension` instead (default: `1`)
 
 ## Format on Save
 
@@ -47,7 +47,7 @@ To enable format on save, add this to your coc-config (`:CocConfig`):
 }
 ```
 
-oxfmt also registers itself with `oxc.oxfmt.formatterPriority` `1` by default, which outranks any extension that does not set a priority. Tune that value if you need finer control.
+oxfmt also registers itself with `oxc.oxfmt.formatterPriority` `1` by default, which outranks any extension that does not set a priority.
 
 You can also format manually with `:call CocAction('format')`
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "oxc.oxfmt.formatterPriority": {
           "type": "number",
           "default": 1,
-          "description": "Priority of the oxfmt formatter when multiple formatters are registered for a language. Higher wins. Set to a negative value to defer to other formatters."
+          "description": "Priority of the oxfmt formatter when multiple formatters are registered for a language. Only positive values boost; the default of 1 outranks formatters that do not set a priority. To defer to another formatter for a given language, use coc.preferences.formatterExtension instead."
         }
       }
     },


### PR DESCRIPTION
## Summary

Follow-up to #195. While verifying the new code I checked coc.nvim's actual provider-selection logic:

```typescript
if (typeof priority == 'number' && priority > 0) {
  score = score + priority
}
```

Only positive priorities are added to the match score — zero and negative values are silently ignored. The previous description told users they could "set a negative value to defer to other formatters", which is false. Negative priorities behave identically to zero (no boost). The actual way to defer is `coc.preferences.formatterExtension`.

Updated the README and package.json description accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)