### PR TITLE
feat: support codeActionsOnSave for oxlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - `oxc.oxlint.run`: Run the linter on save `onSave` or on type `onType` (default: `onType`)
 - `oxc.oxlint.configPath`: Path to oxlint configuration (default: `null`, searches for `.oxlintrc.json`)
 - `oxc.oxlint.binPath`: Path to the `oxlint` binary (default: searches in `node_modules/.bin`)
+- `oxc.oxlint.codeActionsOnSave`: Code action kinds to apply on save, e.g. `["source.fixAll.oxc"]` (default: `[]`, disabled)
 
 ### Oxfmt (Formatter)
 
@@ -50,6 +51,16 @@ To enable format on save, add this to your coc-config (`:CocConfig`):
 oxfmt also registers itself with `oxc.oxfmt.formatterPriority` `1` by default, which outranks any extension that does not set a priority.
 
 You can also format manually with `:call CocAction('format')`
+
+## Fix on Save
+
+To apply oxlint's auto-fixes on save, add this to your coc-config (`:CocConfig`):
+
+```json
+{
+  "oxc.oxlint.codeActionsOnSave": ["source.fixAll.oxc"]
+}
+```
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,15 @@
           "default": null,
           "description": "Path to oxlint configuration. Keep it empty to enable nested configuration."
         },
+        "oxc.oxlint.codeActionsOnSave": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Code action kinds to apply on save (e.g. `source.fixAll.oxc`). Leave empty to disable."
+        },
         "oxc.oxfmt.enable": {
           "type": "boolean",
           "default": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,20 +1,12 @@
 import { existsSync } from "node:fs";
 import { join } from "path";
 import {
-  CancellationTokenSource,
-  CodeAction,
-  CodeActionContext,
-  Command,
   Executable,
   ExtensionContext,
   LanguageClient,
   LanguageClientOptions,
   OutputChannel,
-  Position,
-  Range,
   ServerOptions,
-  TextDocumentIdentifier,
-  WillSaveEvent,
   commands,
   services,
   window,
@@ -135,63 +127,21 @@ function configureClient(config: ClientConfig, context: ExtensionContext, client
         const kinds = workspace
           .getConfiguration("oxc.oxlint", event.document.uri)
           .get<string[]>("codeActionsOnSave", []);
-        if (kinds.length === 0) {
+        if (!kinds.includes("source.fixAll.oxc")) {
           return;
         }
-        event.waitUntil(applyCodeActionsOnSave(client, event, kinds));
+        event.waitUntil(
+          client
+            .sendRequest("workspace/executeCommand", {
+              command: "oxc.fixAll",
+              arguments: [{ uri: event.document.uri }],
+            })
+            .catch((err) => client.error("codeActionsOnSave failed", err)),
+        );
       }),
     );
   }
 }
-
-// Each edit mutates the buffer, so the next request must observe the previous result.
-// oxlint-disable no-await-in-loop
-async function applyCodeActionsOnSave(
-  client: LanguageClient,
-  event: WillSaveEvent,
-  kinds: string[],
-): Promise<void> {
-  const document = event.document;
-  const range = Range.create(Position.create(0, 0), document.end);
-  const tokenSource = new CancellationTokenSource();
-
-  try {
-    for (const kind of kinds) {
-      const context: CodeActionContext = { diagnostics: [], only: [kind] };
-      const params = {
-        textDocument: TextDocumentIdentifier.create(document.uri),
-        range,
-        context,
-      };
-      const actions = await client.sendRequest<(Command | CodeAction)[] | null>(
-        "textDocument/codeAction",
-        params,
-        tokenSource.token,
-      );
-      if (!actions) continue;
-      for (const action of actions) {
-        if (Command.is(action)) continue;
-        let edit = action.edit;
-        if (!edit && action.data !== undefined) {
-          const resolved = await client.sendRequest<CodeAction>(
-            "codeAction/resolve",
-            action,
-            tokenSource.token,
-          );
-          edit = resolved?.edit;
-        }
-        if (edit) {
-          await workspace.applyEdit(edit);
-        }
-      }
-    }
-  } catch (err) {
-    client.error("codeActionsOnSave failed", err);
-  } finally {
-    tokenSource.dispose();
-  }
-}
-// oxlint-enable no-await-in-loop
 
 export function createActivate(config: ClientConfig): (context: ExtensionContext) => Promise<void> {
   return async (context: ExtensionContext): Promise<void> => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,12 +1,20 @@
 import { existsSync } from "node:fs";
 import { join } from "path";
 import {
+  CancellationTokenSource,
+  CodeAction,
+  CodeActionContext,
+  Command,
   Executable,
   ExtensionContext,
   LanguageClient,
   LanguageClientOptions,
   OutputChannel,
+  Position,
+  Range,
   ServerOptions,
+  TextDocumentIdentifier,
+  WillSaveEvent,
   commands,
   services,
   window,
@@ -117,7 +125,72 @@ function configureClient(config: ClientConfig, context: ExtensionContext, client
     );
     void client.sendNotification("workspace/didChangeConfiguration", { settings });
   });
+
+  if (config.name === "oxlint") {
+    context.subscriptions.push(
+      workspace.onWillSaveTextDocument((event) => {
+        if (!config.languages.includes(event.document.languageId)) {
+          return;
+        }
+        const kinds = workspace
+          .getConfiguration("oxc.oxlint", event.document.uri)
+          .get<string[]>("codeActionsOnSave", []);
+        if (kinds.length === 0) {
+          return;
+        }
+        event.waitUntil(applyCodeActionsOnSave(client, event, kinds));
+      }),
+    );
+  }
 }
+
+/* eslint-disable no-await-in-loop -- each edit mutates the buffer, so the next request must observe the previous result */
+async function applyCodeActionsOnSave(
+  client: LanguageClient,
+  event: WillSaveEvent,
+  kinds: string[],
+): Promise<void> {
+  const document = event.document;
+  const range = Range.create(Position.create(0, 0), document.end);
+  const tokenSource = new CancellationTokenSource();
+
+  try {
+    for (const kind of kinds) {
+      const context: CodeActionContext = { diagnostics: [], only: [kind] };
+      const params = {
+        textDocument: TextDocumentIdentifier.create(document.uri),
+        range,
+        context,
+      };
+      const actions = await client.sendRequest<(Command | CodeAction)[] | null>(
+        "textDocument/codeAction",
+        params,
+        tokenSource.token,
+      );
+      if (!actions) continue;
+      for (const action of actions) {
+        if (Command.is(action)) continue;
+        let edit = action.edit;
+        if (!edit && action.data !== undefined) {
+          const resolved = await client.sendRequest<CodeAction>(
+            "codeAction/resolve",
+            action,
+            tokenSource.token,
+          );
+          edit = resolved?.edit;
+        }
+        if (edit) {
+          await workspace.applyEdit(edit);
+        }
+      }
+    }
+  } catch (err) {
+    client.error("codeActionsOnSave failed", err);
+  } finally {
+    tokenSource.dispose();
+  }
+}
+/* eslint-enable no-await-in-loop */
 
 export function createActivate(config: ClientConfig): (context: ExtensionContext) => Promise<void> {
   return async (context: ExtensionContext): Promise<void> => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -144,7 +144,8 @@ function configureClient(config: ClientConfig, context: ExtensionContext, client
   }
 }
 
-/* eslint-disable no-await-in-loop -- each edit mutates the buffer, so the next request must observe the previous result */
+// Each edit mutates the buffer, so the next request must observe the previous result.
+// oxlint-disable no-await-in-loop
 async function applyCodeActionsOnSave(
   client: LanguageClient,
   event: WillSaveEvent,
@@ -190,7 +191,7 @@ async function applyCodeActionsOnSave(
     tokenSource.dispose();
   }
 }
-/* eslint-enable no-await-in-loop */
+// oxlint-enable no-await-in-loop
 
 export function createActivate(config: ClientConfig): (context: ExtensionContext) => Promise<void> {
   return async (context: ExtensionContext): Promise<void> => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,11 +14,10 @@ const mocks = vi.hoisted(() => {
   > = [];
   const willSaveListeners: Array<
     (event: {
-      document: { uri: string; languageId: string; end: { line: number; character: number } };
+      document: { uri: string; languageId: string };
       waitUntil: (thenable: Promise<unknown>) => void;
     }) => void
   > = [];
-  const appliedEdits: unknown[] = [];
 
   class MockLanguageClient {
     id: string;
@@ -90,7 +89,7 @@ const mocks = vi.hoisted(() => {
     onWillSaveTextDocument: vi.fn(
       (
         listener: (event: {
-          document: { uri: string; languageId: string; end: { line: number; character: number } };
+          document: { uri: string; languageId: string };
           waitUntil: (thenable: Promise<unknown>) => void;
         }) => void,
       ) => {
@@ -98,10 +97,6 @@ const mocks = vi.hoisted(() => {
         return { dispose: vi.fn() };
       },
     ),
-    applyEdit: vi.fn(async (edit: unknown) => {
-      appliedEdits.push(edit);
-      return true;
-    }),
   };
 
   function reset() {
@@ -126,7 +121,6 @@ const mocks = vi.hoisted(() => {
     outputChannels.length = 0;
     configurationListeners.length = 0;
     willSaveListeners.length = 0;
-    appliedEdits.length = 0;
 
     existsSync.mockReset();
     existsSync.mockImplementation((_path: string) => false);
@@ -139,7 +133,6 @@ const mocks = vi.hoisted(() => {
     workspace.getConfiguration.mockClear();
     workspace.onDidChangeConfiguration.mockClear();
     workspace.onWillSaveTextDocument.mockClear();
-    workspace.applyEdit.mockClear();
   }
 
   return {
@@ -150,7 +143,6 @@ const mocks = vi.hoisted(() => {
     outputChannels,
     configurationListeners,
     willSaveListeners,
-    appliedEdits,
     existsSync,
     commands,
     services,
@@ -171,35 +163,6 @@ vi.mock("coc.nvim", () => ({
   services: mocks.services,
   window: mocks.window,
   workspace: mocks.workspace,
-  CancellationTokenSource: class {
-    token = { isCancellationRequested: false };
-    dispose() {}
-  },
-  Position: {
-    create: (line: number, character: number) => ({ line, character }),
-  },
-  Range: {
-    create: (
-      startOrLine: number | { line: number; character: number },
-      startCharOrEnd: number | { line: number; character: number },
-      endLine?: number,
-      endCharacter?: number,
-    ) => {
-      if (typeof startOrLine === "number") {
-        return {
-          start: { line: startOrLine, character: startCharOrEnd as number },
-          end: { line: endLine!, character: endCharacter! },
-        };
-      }
-      return { start: startOrLine, end: startCharOrEnd as { line: number; character: number } };
-    },
-  },
-  TextDocumentIdentifier: {
-    create: (uri: string) => ({ uri }),
-  },
-  Command: {
-    is: (value: unknown) => typeof (value as { command?: unknown }).command === "string",
-  },
 }));
 
 beforeEach(() => {
@@ -295,7 +258,7 @@ describe("extension activation", () => {
     expect(oxfmtClient?.clientOptions).toMatchObject({ formatterPriority: 5 });
   });
 
-  it("requests source.fixAll.oxc on save and applies returned edits", async () => {
+  it("runs oxc.fixAll on save when source.fixAll.oxc is configured", async () => {
     mocks.configurationValues["oxc.oxlint"] = {
       enable: true,
       binPath: "/mock/bin/oxlint",
@@ -304,45 +267,28 @@ describe("extension activation", () => {
     mocks.configurationValues["oxc.oxfmt"] = { enable: false };
     mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxlint");
 
-    const expectedEdit = { changes: { "file:///mock/foo.ts": [] } };
     const { activate } = await import("./index");
     await activate({ subscriptions: [] as unknown[] } as never);
 
     const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
-    oxlintClient.sendRequest.mockResolvedValueOnce([
-      { title: "Fix all", kind: "source.fixAll.oxc", edit: expectedEdit },
-    ]);
 
     expect(mocks.willSaveListeners).toHaveLength(1);
     const waited: Promise<unknown>[] = [];
     mocks.willSaveListeners[0]({
-      document: {
-        uri: "file:///mock/foo.ts",
-        languageId: "typescript",
-        end: { line: 10, character: 0 },
-      },
+      document: { uri: "file:///mock/foo.ts", languageId: "typescript" },
       waitUntil: (thenable) => {
         waited.push(Promise.resolve(thenable));
       },
     });
     await Promise.all(waited);
 
-    expect(oxlintClient.sendRequest).toHaveBeenCalledWith(
-      "textDocument/codeAction",
-      expect.objectContaining({
-        textDocument: { uri: "file:///mock/foo.ts" },
-        context: { diagnostics: [], only: ["source.fixAll.oxc"] },
-        range: expect.objectContaining({
-          start: { line: 0, character: 0 },
-          end: { line: 10, character: 0 },
-        }),
-      }),
-      expect.anything(),
-    );
-    expect(mocks.appliedEdits).toEqual([expectedEdit]);
+    expect(oxlintClient.sendRequest).toHaveBeenCalledWith("workspace/executeCommand", {
+      command: "oxc.fixAll",
+      arguments: [{ uri: "file:///mock/foo.ts" }],
+    });
   });
 
-  it("skips on-save code actions when no kinds are configured or language does not match", async () => {
+  it("skips on-save fix when source.fixAll.oxc is not configured or language does not match", async () => {
     mocks.configurationValues["oxc.oxlint"] = {
       enable: true,
       binPath: "/mock/bin/oxlint",
@@ -357,22 +303,14 @@ describe("extension activation", () => {
     const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
 
     mocks.willSaveListeners[0]({
-      document: {
-        uri: "file:///mock/foo.ts",
-        languageId: "typescript",
-        end: { line: 0, character: 0 },
-      },
+      document: { uri: "file:///mock/foo.ts", languageId: "typescript" },
       waitUntil: () => {},
     });
     expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
 
     mocks.configurationValues["oxc.oxlint"].codeActionsOnSave = ["source.fixAll.oxc"];
     mocks.willSaveListeners[0]({
-      document: {
-        uri: "file:///mock/foo.css",
-        languageId: "css",
-        end: { line: 0, character: 0 },
-      },
+      document: { uri: "file:///mock/foo.css", languageId: "css" },
       waitUntil: () => {},
     });
     expect(oxlintClient.sendRequest).not.toHaveBeenCalled();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,13 @@ const mocks = vi.hoisted(() => {
   const configurationListeners: Array<
     (event: { affectsConfiguration: (section: string) => boolean }) => void
   > = [];
+  const willSaveListeners: Array<
+    (event: {
+      document: { uri: string; languageId: string; end: { line: number; character: number } };
+      waitUntil: (thenable: Promise<unknown>) => void;
+    }) => void
+  > = [];
+  const appliedEdits: unknown[] = [];
 
   class MockLanguageClient {
     id: string;
@@ -20,6 +27,7 @@ const mocks = vi.hoisted(() => {
     clientOptions: Record<string, unknown>;
     restart = vi.fn(async () => undefined);
     sendNotification = vi.fn();
+    sendRequest = vi.fn(async (_method: string, _params: unknown) => null as unknown);
     error = vi.fn();
 
     constructor(
@@ -79,6 +87,21 @@ const mocks = vi.hoisted(() => {
         return { dispose: vi.fn() };
       },
     ),
+    onWillSaveTextDocument: vi.fn(
+      (
+        listener: (event: {
+          document: { uri: string; languageId: string; end: { line: number; character: number } };
+          waitUntil: (thenable: Promise<unknown>) => void;
+        }) => void,
+      ) => {
+        willSaveListeners.push(listener);
+        return { dispose: vi.fn() };
+      },
+    ),
+    applyEdit: vi.fn(async (edit: unknown) => {
+      appliedEdits.push(edit);
+      return true;
+    }),
   };
 
   function reset() {
@@ -102,6 +125,8 @@ const mocks = vi.hoisted(() => {
     registeredCommands.length = 0;
     outputChannels.length = 0;
     configurationListeners.length = 0;
+    willSaveListeners.length = 0;
+    appliedEdits.length = 0;
 
     existsSync.mockReset();
     existsSync.mockImplementation((_path: string) => false);
@@ -113,6 +138,8 @@ const mocks = vi.hoisted(() => {
     window.showInformationMessage.mockClear();
     workspace.getConfiguration.mockClear();
     workspace.onDidChangeConfiguration.mockClear();
+    workspace.onWillSaveTextDocument.mockClear();
+    workspace.applyEdit.mockClear();
   }
 
   return {
@@ -122,6 +149,8 @@ const mocks = vi.hoisted(() => {
     registeredCommands,
     outputChannels,
     configurationListeners,
+    willSaveListeners,
+    appliedEdits,
     existsSync,
     commands,
     services,
@@ -142,6 +171,35 @@ vi.mock("coc.nvim", () => ({
   services: mocks.services,
   window: mocks.window,
   workspace: mocks.workspace,
+  CancellationTokenSource: class {
+    token = { isCancellationRequested: false };
+    dispose() {}
+  },
+  Position: {
+    create: (line: number, character: number) => ({ line, character }),
+  },
+  Range: {
+    create: (
+      startOrLine: number | { line: number; character: number },
+      startCharOrEnd: number | { line: number; character: number },
+      endLine?: number,
+      endCharacter?: number,
+    ) => {
+      if (typeof startOrLine === "number") {
+        return {
+          start: { line: startOrLine, character: startCharOrEnd as number },
+          end: { line: endLine!, character: endCharacter! },
+        };
+      }
+      return { start: startOrLine, end: startCharOrEnd as { line: number; character: number } };
+    },
+  },
+  TextDocumentIdentifier: {
+    create: (uri: string) => ({ uri }),
+  },
+  Command: {
+    is: (value: unknown) => typeof (value as { command?: unknown }).command === "string",
+  },
 }));
 
 beforeEach(() => {
@@ -235,6 +293,89 @@ describe("extension activation", () => {
 
     const oxfmtClient = mocks.createdClients.find((client) => client.name === "oxfmt");
     expect(oxfmtClient?.clientOptions).toMatchObject({ formatterPriority: 5 });
+  });
+
+  it("requests source.fixAll.oxc on save and applies returned edits", async () => {
+    mocks.configurationValues["oxc.oxlint"] = {
+      enable: true,
+      binPath: "/mock/bin/oxlint",
+      codeActionsOnSave: ["source.fixAll.oxc"],
+    };
+    mocks.configurationValues["oxc.oxfmt"] = { enable: false };
+    mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxlint");
+
+    const expectedEdit = { changes: { "file:///mock/foo.ts": [] } };
+    const { activate } = await import("./index");
+    await activate({ subscriptions: [] as unknown[] } as never);
+
+    const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
+    oxlintClient.sendRequest.mockResolvedValueOnce([
+      { title: "Fix all", kind: "source.fixAll.oxc", edit: expectedEdit },
+    ]);
+
+    expect(mocks.willSaveListeners).toHaveLength(1);
+    const waited: Promise<unknown>[] = [];
+    mocks.willSaveListeners[0]({
+      document: {
+        uri: "file:///mock/foo.ts",
+        languageId: "typescript",
+        end: { line: 10, character: 0 },
+      },
+      waitUntil: (thenable) => {
+        waited.push(Promise.resolve(thenable));
+      },
+    });
+    await Promise.all(waited);
+
+    expect(oxlintClient.sendRequest).toHaveBeenCalledWith(
+      "textDocument/codeAction",
+      expect.objectContaining({
+        textDocument: { uri: "file:///mock/foo.ts" },
+        context: { diagnostics: [], only: ["source.fixAll.oxc"] },
+        range: expect.objectContaining({
+          start: { line: 0, character: 0 },
+          end: { line: 10, character: 0 },
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mocks.appliedEdits).toEqual([expectedEdit]);
+  });
+
+  it("skips on-save code actions when no kinds are configured or language does not match", async () => {
+    mocks.configurationValues["oxc.oxlint"] = {
+      enable: true,
+      binPath: "/mock/bin/oxlint",
+      codeActionsOnSave: [],
+    };
+    mocks.configurationValues["oxc.oxfmt"] = { enable: false };
+    mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxlint");
+
+    const { activate } = await import("./index");
+    await activate({ subscriptions: [] as unknown[] } as never);
+
+    const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
+
+    mocks.willSaveListeners[0]({
+      document: {
+        uri: "file:///mock/foo.ts",
+        languageId: "typescript",
+        end: { line: 0, character: 0 },
+      },
+      waitUntil: () => {},
+    });
+    expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
+
+    mocks.configurationValues["oxc.oxlint"].codeActionsOnSave = ["source.fixAll.oxc"];
+    mocks.willSaveListeners[0]({
+      document: {
+        uri: "file:///mock/foo.css",
+        languageId: "css",
+        end: { line: 0, character: 0 },
+      },
+      waitUntil: () => {},
+    });
+    expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
   });
 
   it("skips activation for disabled clients", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -258,11 +258,30 @@ describe("extension activation", () => {
     expect(oxfmtClient?.clientOptions).toMatchObject({ formatterPriority: 5 });
   });
 
-  it("runs oxc.fixAll on save when source.fixAll.oxc is configured", async () => {
+  it.each([
+    {
+      name: "runs oxc.fixAll when source.fixAll.oxc is configured and language matches",
+      kinds: ["source.fixAll.oxc"],
+      languageId: "typescript",
+      expectRequest: true,
+    },
+    {
+      name: "skips when codeActionsOnSave is empty",
+      kinds: [],
+      languageId: "typescript",
+      expectRequest: false,
+    },
+    {
+      name: "skips when language is not in the oxlint document selector",
+      kinds: ["source.fixAll.oxc"],
+      languageId: "css",
+      expectRequest: false,
+    },
+  ])("$name", async ({ kinds, languageId, expectRequest }) => {
     mocks.configurationValues["oxc.oxlint"] = {
       enable: true,
       binPath: "/mock/bin/oxlint",
-      codeActionsOnSave: ["source.fixAll.oxc"],
+      codeActionsOnSave: kinds,
     };
     mocks.configurationValues["oxc.oxfmt"] = { enable: false };
     mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxlint");
@@ -271,49 +290,23 @@ describe("extension activation", () => {
     await activate({ subscriptions: [] as unknown[] } as never);
 
     const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
-
-    expect(mocks.willSaveListeners).toHaveLength(1);
     const waited: Promise<unknown>[] = [];
     mocks.willSaveListeners[0]({
-      document: { uri: "file:///mock/foo.ts", languageId: "typescript" },
+      document: { uri: "file:///mock/foo", languageId },
       waitUntil: (thenable) => {
         waited.push(Promise.resolve(thenable));
       },
     });
     await Promise.all(waited);
 
-    expect(oxlintClient.sendRequest).toHaveBeenCalledWith("workspace/executeCommand", {
-      command: "oxc.fixAll",
-      arguments: [{ uri: "file:///mock/foo.ts" }],
-    });
-  });
-
-  it("skips on-save fix when source.fixAll.oxc is not configured or language does not match", async () => {
-    mocks.configurationValues["oxc.oxlint"] = {
-      enable: true,
-      binPath: "/mock/bin/oxlint",
-      codeActionsOnSave: [],
-    };
-    mocks.configurationValues["oxc.oxfmt"] = { enable: false };
-    mocks.existsSync.mockImplementation((path: string) => path === "/mock/bin/oxlint");
-
-    const { activate } = await import("./index");
-    await activate({ subscriptions: [] as unknown[] } as never);
-
-    const oxlintClient = mocks.createdClients.find((client) => client.name === "oxlint")!;
-
-    mocks.willSaveListeners[0]({
-      document: { uri: "file:///mock/foo.ts", languageId: "typescript" },
-      waitUntil: () => {},
-    });
-    expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
-
-    mocks.configurationValues["oxc.oxlint"].codeActionsOnSave = ["source.fixAll.oxc"];
-    mocks.willSaveListeners[0]({
-      document: { uri: "file:///mock/foo.css", languageId: "css" },
-      waitUntil: () => {},
-    });
-    expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
+    if (expectRequest) {
+      expect(oxlintClient.sendRequest).toHaveBeenCalledWith("workspace/executeCommand", {
+        command: "oxc.fixAll",
+        arguments: [{ uri: "file:///mock/foo" }],
+      });
+    } else {
+      expect(oxlintClient.sendRequest).not.toHaveBeenCalled();
+    }
   });
 
   it("skips activation for disabled clients", async () => {


### PR DESCRIPTION
## Summary
- Adds `oxc.oxlint.codeActionsOnSave` config (string array, e.g. `["source.fixAll.oxc"]`).
- On save, when `source.fixAll.oxc` is in the array and the document language is in oxlint's selector, the extension calls `workspace/executeCommand` with `oxc.fixAll` on the oxlint LSP. The server applies the edits via server-driven `workspace/applyEdit`, mirroring [oxc-vscode's `applyAllFixesFile` command](https://github.com/oxc-project/oxc-vscode/blob/main/client/tools/linter.ts).
- README gets a "Fix on Save" section with a copy-paste snippet.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)