### PR TITLE
ci: drop redundant global npm install before pnpm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
 
       - run: pnpm run build
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - run: pnpm publish --tag latest --provenance --access public
 
       - name: Create GitHub Release


### PR DESCRIPTION
Removes the redundant `npm install -g npm@latest` step. Publishing already uses `pnpm publish`, so the globally-installed npm version has no effect and the step can be dropped.