### PR TITLE
test: fix test failure on Windows due to path separator mismatch

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { join } from "path";
 
 const mocks = vi.hoisted(() => {
   const configurationValues: Record<string, Record<string, unknown>> = {};
@@ -182,10 +183,10 @@ describe("extension activation", () => {
       enable: true,
       binPath: "/mock/bin/oxfmt",
     };
-    mocks.existsSync.mockImplementation(
-      (path: string) =>
-        path === "/mock-workspace/node_modules/.bin/oxlint" || path === "/mock/bin/oxfmt",
-    );
+    mocks.existsSync.mockImplementation((path: string) => {
+      const p = path.replace(/\\/g, "/");
+      return p === "/mock-workspace/node_modules/.bin/oxlint" || p === "/mock/bin/oxfmt";
+    });
 
     const { activate } = await import("./index");
     const context = { subscriptions: [] as unknown[] };
@@ -204,7 +205,7 @@ describe("extension activation", () => {
     const [oxlintClient, oxfmtClient] = mocks.createdClients;
     expect(oxlintClient.serverOptions).toMatchObject({
       run: {
-        command: "/mock-workspace/node_modules/.bin/oxlint",
+        command: join("/mock-workspace", "node_modules", ".bin", "oxlint"),
         args: ["--lsp"],
       },
     });


### PR DESCRIPTION
### Description
This PR fixes a test failure that occurs when running the automated tests on a Windows environment. 

The issue was caused by strict path string matching in `src/index.test.ts`. The tests were hardcoded to expect POSIX-style paths (e.g., `/mock-workspace/node_modules/.bin/oxlint`), which caused failures on Windows where `path.join()` generates paths using backslashes (e.g., `\mock-workspace\node_modules\.bin\oxlint`).

### Changes Made
- Imported `join` from `path` in the test file.
- Replaced the hardcoded POSIX path string in the `serverOptions` expectation with `join()` to dynamically match the OS's path format.
- Normalized the paths in the `existsSync` mock to ensure they consistently match regardless of whether forward slashes or backslashes are used.

### Related Issues
Fixes #236 

### Testing
- [x] Verified tests pass successfully on Windows (`pnpm exec vp test`)
